### PR TITLE
Mainmon - Main monitor for the statusbar

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -36,6 +36,7 @@ static const float mfact     = 0.55; /* factor of master area size [0.05..0.95] 
 static const int nmaster     = 1;    /* number of clients in master area */
 static const int resizehints = 1;    /* 1 means respect size hints in tiled resizals */
 static const int lockfullscreen = 1; /* 1 will force focus on the fullscreen window */
+static const int mainmon = 0; /* xsetroot will only change the bar on this monitor */
 
 static const Layout layouts[] = {
 	/* symbol     arrange function */

--- a/dwm.c
+++ b/dwm.c
@@ -708,7 +708,7 @@ drawbar(Monitor *m)
 		return;
 
 	/* draw status first so it can be overdrawn by tags later */
-	if (m == selmon) { /* status is only drawn on selected monitor */
+	if (m == &mons[mainmon]) { /* status is only drawn on main monitor */
 		drw_setscheme(drw, scheme[SchemeNorm]);
 		tw = TEXTW(stext) - lrpad + 2; /* 2px right padding */
 		drw_text(drw, m->ww - tw, 0, tw, bh, 0, stext, 0);


### PR DESCRIPTION
This small patch add a mainmon value to the config.def.h. It let's the user choose a monitor on which to have the statusbar show-up. The status will no longer follow which monitor is currently selected.

It is especially usefull in two scenarios:
- A monitor is setup vertically and has little room for the status.
- Dwm is used in a public environment and it's user does not want the contents of the status bar to be shown (i.e. on a projector).